### PR TITLE
Add ComfyStudio to text-to-image Tools and Frameworks

### DIFF
--- a/docs/text-to-image.md
+++ b/docs/text-to-image.md
@@ -71,6 +71,12 @@
 - **Flexibility**: Modular pipelines
 - **Best for**: Rapid prototyping and creative workflows
 
+### [ComfyStudio](https://comfystudio.io/)
+- **Type**: Browser-based AI illustration and short-video studio
+- **Features**: 27 curated ComfyUI / fal.ai workflows (FLUX, Wan, Kling, Seedance, HunyuanVideo, LTX, Vidu) with no install or local GPU
+- **Flexibility**: Per-generation resolution + length controls; transparent 1-credit = 1-yen pricing
+- **Best for**: Anime / manga / VTuber / indie-game creators who want curated workflows without ComfyUI knowledge
+
 ---
 
 ## Models and Platforms


### PR DESCRIPTION
Adds ComfyStudio (https://comfystudio.io/) to docs/text-to-image.md under Tools and Frameworks.

ComfyStudio is a managed cloud SaaS that wraps ComfyUI / fal.ai workflows behind a simple browser UI. We package 27 admin-curated workflows (image styles, video models including Wan / Kling / Seedance / HunyuanVideo / LTX / Vidu, and image-edit pipelines) and route them to ComfyUI Cloud / fal.ai transparently. Specialized for anime, manga, VTuber and indie-game creators.

- Free tier: 100 credits at signup, no credit card required
- Transparent 1 credit = 1 JPY pricing
- All outputs licensed for commercial use
- Explicitly safe-for-work (no NSFW or real-person manipulation)

Self-disclosure: I'm the founder of ComfyStudio. Happy to adjust the entry to match the list's preferred style.