### PR TITLE
Add igly.ai to text-to-image tools

### DIFF
--- a/docs/text-to-image.md
+++ b/docs/text-to-image.md
@@ -71,6 +71,12 @@
 - **Flexibility**: Modular pipelines
 - **Best for**: Rapid prototyping and creative workflows
 
+### [igly.ai](https://igly.ai)
+- **Type**: AI image editing platform
+- **Features**: Background removal, inpainting, upscaling, and generative fill
+- **Accessibility**: Browser-based editor
+- **Best for**: Fast visual edits and creator workflows
+
 ---
 
 ## Models and Platforms


### PR DESCRIPTION
## Summary
- Add igly.ai to the Text-to-Image tools and frameworks page.
- It is a browser-based AI image editor for background removal, inpainting, upscaling, and generative fill.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is