### PR TITLE
Add GPTGeminiGrok.AI to commercial platforms

### DIFF
--- a/docs/text-to-image.md
+++ b/docs/text-to-image.md
@@ -92,6 +92,7 @@
 - **Midjourney** - Artistic generation
 - **Adobe Firefly** - Creative suite integration
 - **Canva AI** - Design tool integration
+- **[GPTGeminiGrok.AI](https://trygrokai.asia/)** - Browser workspace for GPT, Gemini, Grok, and Claude with image generation and API access
 
 ### Specialized Models
 - **ControlNet** - Controllable generation


### PR DESCRIPTION
Adds GPTGeminiGrok.AI to the commercial platforms section of the text-to-image guide. It provides a browser workspace for GPT, Gemini, Grok, and Claude with image generation and API access.

Website: https://trygrokai.asia/