### PR TITLE
docs: add Rao Edits to text-to-image platforms

### DIFF
--- a/docs/text-to-image.md
+++ b/docs/text-to-image.md
@@ -93,6 +93,7 @@
 - **Adobe Firefly** - Creative suite integration
 - **Canva AI** - Design tool integration
 - **[GPTGeminiGrok.AI](https://trygrokai.asia/)** - Browser workspace for GPT, Gemini, Grok, and Claude with image generation and API access
+- **[Rao Edits](https://raoedits.top/)** - Web platform for text-to-image generation and reference-image editing
 
 ### Specialized Models
 - **ControlNet** - Controllable generation


### PR DESCRIPTION
## Summary

- add Rao Edits to the Commercial Platforms section in docs/text-to-image.md`n- use a concise factual description for its text-to-image and reference-image editing capabilities

## Checks

- confirmed the official HTTPS link returns HTTP 200
- confirmed there is no existing Rao Edits entry
- kept the change to one line in the relevant section

Disclosure: I am submitting this project listing on behalf of Rao Edits.