### PR TITLE
Add OrkasVideoStudio to creative MCP tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -234,6 +234,12 @@
 - **Platform**: Autodesk Maya
 - **Best for**: Professional 3D animation
 
+### [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio)
+- **Type**: Agent-driven video composition and editing
+- **Features**: Editable timelines, generation, automatic assembly
+- **Platform**: TypeScript CLI and MCP server
+- **Best for**: Coding-agent video workflows
+
 ---
 
 ## Marketing and SEO


### PR DESCRIPTION
## Summary

- add OrkasVideoStudio under Art and Creative Tools
- describe its editable timelines, video workflow, TypeScript CLI, and MCP server
- keep each field concise and factual

## Verification

- confirmed there was no existing OrkasVideoStudio entry
- `git diff --check`