### PR TITLE
Add Seele TV cinematic video studio

### DIFF
--- a/docs/text-to-image.md
+++ b/docs/text-to-image.md
@@ -71,6 +71,12 @@
 - **Flexibility**: Modular pipelines
 - **Best for**: Rapid prototyping and creative workflows
 
+### [Seele TV](https://seele.tv)
+- **Type**: Controllable AI video studio
+- **Features**: Visual references, shot-level camera direction, and scene-continuity workflows
+- **Accessibility**: Browser-based workspace
+- **Best for**: Reference-led cinematic sequences
+
 ### [igly.ai](https://igly.ai)
 - **Type**: AI image editing platform
 - **Features**: Background removal, inpainting, upscaling, and generative fill


### PR DESCRIPTION
Adds Seele TV (https://seele.tv), a controllable AI video studio for reference-led cinematic sequences, shot-level camera direction, and scene continuity. The entry is placed in the repository's video-related section and uses a concise factual description.

Disclosure: submitted on behalf of Seele TV.
