### PR TITLE
Add SandBase to GenAI API tools

### DIFF
--- a/docs/genai-apis.md
+++ b/docs/genai-apis.md
@@ -104,6 +104,8 @@
 - **Streaming** - Real-time responses
 - **Function Calling** - Structured outputs
 
+- [SandBase](https://github.com/sandbaseai/cli) - CLI and MCP bridge for 2,000+ AI models and APIs.
+
 ---
 
 ## 💡 **Implementation Examples**
@@ -203,4 +205,3 @@ with open("output.wav", "wb") as f:
 ---
 
 > **💡 Tip**: Start with free tiers to experiment, then scale up based on your specific needs and usage patterns.
-

--- a/docs/genai-apis.md
+++ b/docs/genai-apis.md
@@ -104,7 +104,7 @@
 - **Streaming** - Real-time responses
 - **Function Calling** - Structured outputs
 
-- [SandBase](https://github.com/sandbaseai/cli) - CLI and MCP bridge for 2,000+ AI models and APIs.
+- [SandBase](https://github.com/sandbaseai/cli) - CLI and MCP bridge for 2,000+ AI models.
 
 ---
 


### PR DESCRIPTION
## Summary

- add SandBase to the Generative AI API development tools section
- describe its open-source CLI and MCP access to 2,000+ AI models
- keep the entry concise and link the official repository

## Validation

- confirmed there is no existing SandBase entry
- changed only `docs/genai-apis.md`
- ran `git diff --check`

## Disclosure

I am affiliated with SandBase. This submission was prepared with AI assistance and reviewed for factual accuracy and repository fit.